### PR TITLE
Bug/json agg null filter

### DIFF
--- a/models/db/artifact/index.js
+++ b/models/db/artifact/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const db = require('../../db');
+const db = require('../conn');
 
 const create = (email, register_id, name, family_members, description, date, lat, lon) => {
   return db.knex('membership')


### PR DESCRIPTION
Array photos in artifact object now returns `[]` instead of `[null]` when there are no photos associated with an artifact

Sorry about that last PR.